### PR TITLE
NumericRounder: Preserve boolean type

### DIFF
--- a/structlog_pretty/processors.py
+++ b/structlog_pretty/processors.py
@@ -42,11 +42,15 @@ class NumericRounder(object):
 
     def __call__(self, _, __, event_dict):
         for key, value in event_dict.items():
-            if self.only_fields is None or key in self.only_fields:
-                try:
-                    event_dict[key] = round(value, self.digits)
-                except TypeError:
-                    continue
+            if self.only_fields is not None and key not in self.only_fields:
+                continue
+            if isinstance(value, bool):
+                continue  # don't convert True to 1.0
+
+            try:
+                event_dict[key] = round(value, self.digits)
+            except TypeError:
+                continue
 
         return event_dict
 

--- a/test/test_NumericRounder.py
+++ b/test/test_NumericRounder.py
@@ -16,10 +16,13 @@ from structlog_pretty.processors import NumericRounder as uut
     (Decimal('-1.12345'), Decimal('-1.123')),
     (None, None),
     ('str', 'str'),
+    (True, True),
+    (False, False),
 ])
 def test_run(param, expected):
     processor = uut()
     event_dict = processor(None, None, {'param': param})
+    assert type(event_dict['param']) == type(expected)  # pylint: disable=unidiomatic-typecheck
     assert event_dict == {'param': expected}
 
 


### PR DESCRIPTION
`round()` changed type of value from `bool` to `float`. This
caused issues in processors in a processing pipeline when they use
`if value is ` conditions.

Such an example is an in-built processor [`structlog.processors.format_exc_info`](https://structlog.readthedocs.io/en/0.4.0/api.html#structlog.processors.format_exc_info), which expects value of `exc_info` key to be  either `tuple` or `True`. When `NumericRounder` processor is placed infront of `structlog.processors.format_exc_info`, it changes value of `exc_info` from `True` to `1.0`. `structlog.processors.format_exc_info` then throws exception.

The example with `structlog.processors.format_exc_info`  is based on version 16.0.0 ([_source_](https://github.com/hynek/structlog/blob/8a429b1c6ce045d6f43ae8a093d18bcbc6623325/src/structlog/processors.py#L234)) in version 16.1.0 the logic is slightly different.

Anyway, I believe processor should not change value type in `event_dict` unless it's specifically designed to.