### PR TITLE
prettify_processors: add text is none condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0 (2020-07-08)
+
+ - Fix JSONPrettifier, XMLPrettifier - skip code coloring when there is no code to color.
+
 ## 0.1.1 (2016-12-15)
 
  - Fix NumericRounder converting booleans into floats

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open('README.rst') as f:
 
 setup(
     name='structlog-pretty',
-    version='0.1.1',
+    version='0.2.0',
     url='https://github.com/underyx/structlog-pretty',
     author='Bence Nagy',
     author_email='bence@underyx.me',

--- a/structlog_pretty/processors.py
+++ b/structlog_pretty/processors.py
@@ -90,6 +90,8 @@ class JSONPrettifier(object):
                 code = event_dict[field]
             except KeyError:
                 continue
+            if not code:
+                continue
             event_dict[field] = self.prettify(code)
 
         return event_dict
@@ -137,6 +139,8 @@ class XMLPrettifier(object):
             try:
                 code = event_dict[field]
             except KeyError:
+                continue
+            if not code:
                 continue
             event_dict[field] = self.prettify(code)
 


### PR DESCRIPTION
Hi there Bence,

we still use the `structlog-pretty` in our projects. And having this annoying exception when there is no code to be colored (code=None). This PR should fix it.